### PR TITLE
refactor(sample_sensor_kit_launch): add use_gnss_ins_orientation parameter

### DIFF
--- a/sample_sensor_kit_launch/launch/gnss.launch.xml
+++ b/sample_sensor_kit_launch/launch/gnss.launch.xml
@@ -34,7 +34,7 @@
       <arg name="output_topic_gnss_fixed" value="fixed"/>
 
       <arg name="coordinate_system" value="$(var coordinate_system)"/>
-      <arg name="use_ublox_receiver" value="true"/>
+      <param name="use_gnss_ins_orientation" value="true"/>
 
       <arg name="gnss_frame" value="gnss_link"/>
     </include>

--- a/sample_sensor_kit_launch/launch/gnss.launch.xml
+++ b/sample_sensor_kit_launch/launch/gnss.launch.xml
@@ -34,7 +34,7 @@
       <arg name="output_topic_gnss_fixed" value="fixed"/>
 
       <arg name="coordinate_system" value="$(var coordinate_system)"/>
-      <param name="use_gnss_ins_orientation" value="true"/>
+      <arg name="use_gnss_ins_orientation" value="true"/>
 
       <arg name="gnss_frame" value="gnss_link"/>
     </include>


### PR DESCRIPTION
Signed-off-by: melike tanrikulu <melike@leodrive.ai>

## Description

<!-- Write a brief description of this PR. -->
This PR edits the launch file based on the latest changes in the gnss_poser package. The use_gnss_ins_orientation parameter has been added instead of the use_ublox _receiver parameter.
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
