### PR TITLE
feat(sample_sensor_kit_launch): pass container to velodyne nodes

### DIFF
--- a/common_sensor_launch/launch/velodyne_VLP16.launch.xml
+++ b/common_sensor_launch/launch/velodyne_VLP16.launch.xml
@@ -14,7 +14,7 @@
   <arg name="view_direction" default="0.0"/>
   <arg name="view_width" default="6.28"/>
   <arg name="vehicle_mirror_param_file"/>
-  <arg name="use_pointcloud_container" default="False"/>
+  <arg name="use_pointcloud_container" default="false"/>
   <arg name="container_name" default="velodyne_node_container"/>
 
   <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_node_container.launch.py">

--- a/common_sensor_launch/launch/velodyne_VLP16.launch.xml
+++ b/common_sensor_launch/launch/velodyne_VLP16.launch.xml
@@ -14,6 +14,8 @@
   <arg name="view_direction" default="0.0"/>
   <arg name="view_width" default="6.28"/>
   <arg name="vehicle_mirror_param_file"/>
+  <arg name="use_pointcloud_container" default="False"/>
+  <arg name="container_name" default="velodyne_node_container"/>
 
   <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_node_container.launch.py">
     <arg name="launch_driver" value="$(var launch_driver)"/>
@@ -31,6 +33,8 @@
     <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
     <arg name="use_intra_process" value="true"/>
     <arg name="use_multithread" value="false"/>
+    <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+    <arg name="container_name" value="$(var container_name)"/>
   </include>
 
   <!-- Velodyne Monitor -->

--- a/common_sensor_launch/launch/velodyne_VLS128.launch.xml
+++ b/common_sensor_launch/launch/velodyne_VLS128.launch.xml
@@ -17,6 +17,8 @@
   <arg name="view_direction" default="0.0"/>
   <arg name="view_width" default="6.28"/>
   <arg name="vehicle_mirror_param_file"/>
+  <arg name="use_pointcloud_container" default="False"/>
+  <arg name="container_name" default="velodyne_node_container"/>
 
   <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_node_container.launch.py">
     <arg name="launch_driver" value="$(var launch_driver)"/>
@@ -34,6 +36,8 @@
     <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
     <arg name="use_intra_process" value="true"/>
     <arg name="use_multithread" value="true"/>
+    <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+    <arg name="container_name" value="$(var container_name)"/>
   </include>
 
   <!-- Velodyne Monitor -->

--- a/common_sensor_launch/launch/velodyne_VLS128.launch.xml
+++ b/common_sensor_launch/launch/velodyne_VLS128.launch.xml
@@ -17,7 +17,7 @@
   <arg name="view_direction" default="0.0"/>
   <arg name="view_width" default="6.28"/>
   <arg name="vehicle_mirror_param_file"/>
-  <arg name="use_pointcloud_container" default="False"/>
+  <arg name="use_pointcloud_container" default="false"/>
   <arg name="container_name" default="velodyne_node_container"/>
 
   <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_node_container.launch.py">

--- a/common_sensor_launch/launch/velodyne_node_container.launch.py
+++ b/common_sensor_launch/launch/velodyne_node_container.launch.py
@@ -164,14 +164,20 @@ def launch_setup(context, *args, **kwargs):
         )
     )
 
-    # set container to run all required components in the same process
     container = ComposableNodeContainer(
-        # need unique name, otherwise all processes in same container and the node names then clash
-        name="velodyne_node_container",
+        name=LaunchConfiguration("container_name"),
         namespace="pointcloud_preprocessor",
         package="rclcpp_components",
         executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=nodes,
+        condition=UnlessCondition(LaunchConfiguration("use_pointcloud_container")),
+        output="screen",
+    )
+
+    component_loader = LoadComposableNodes(
+        composable_node_descriptions=nodes,
+        target_container=LaunchConfiguration("container_name"),
+        condition=IfCondition(LaunchConfiguration("use_pointcloud_container")),
     )
 
     driver_component = ComposableNode(
@@ -198,15 +204,19 @@ def launch_setup(context, *args, **kwargs):
         ],
     )
 
-    # one way to add a ComposableNode conditional on a launch argument to a
-    # container. The `ComposableNode` itself doesn't accept a condition
-    loader = LoadComposableNodes(
-        composable_node_descriptions=[driver_component],
-        target_container=container,
-        condition=launch.conditions.IfCondition(LaunchConfiguration("launch_driver")),
+    target_container = (
+        container
+        if UnlessCondition(LaunchConfiguration("use_pointcloud_container")).evaluate(context)
+        else LaunchConfiguration("container_name")
     )
 
-    return [container, loader]
+    driver_component_loader = LoadComposableNodes(
+        composable_node_descriptions=[driver_component],
+        target_container=target_container,
+        condition=IfCondition(LaunchConfiguration("launch_driver")),
+    )
+
+    return [container, component_loader, driver_component_loader]
 
 
 def generate_launch_description():
@@ -248,6 +258,8 @@ def generate_launch_description():
     )
     add_launch_arg("use_multithread", "False", "use multithread")
     add_launch_arg("use_intra_process", "False", "use ROS2 component container communication")
+    add_launch_arg("use_pointcloud_container", "False")
+    add_launch_arg("container_name", "velodyne_node_container")
 
     set_container_executable = SetLaunchConfiguration(
         "container_executable",

--- a/common_sensor_launch/launch/velodyne_node_container.launch.py
+++ b/common_sensor_launch/launch/velodyne_node_container.launch.py
@@ -258,7 +258,7 @@ def generate_launch_description():
     )
     add_launch_arg("use_multithread", "False", "use multithread")
     add_launch_arg("use_intra_process", "False", "use ROS2 component container communication")
-    add_launch_arg("use_pointcloud_container", "False")
+    add_launch_arg("use_pointcloud_container", "false")
     add_launch_arg("container_name", "velodyne_node_container")
 
     set_container_executable = SetLaunchConfiguration(

--- a/sample_sensor_kit_launch/launch/lidar.launch.xml
+++ b/sample_sensor_kit_launch/launch/lidar.launch.xml
@@ -20,6 +20,8 @@
         <!-- <arg name="sensor_timestamp" value="false" /> -->
         <arg name="launch_driver" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
+        <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+        <arg name="container_name" value="$(var pointcloud_container_name)"/>
       </include>
     </group>
 
@@ -34,6 +36,8 @@
         <!-- <arg name="sensor_timestamp" value="false" /> -->
         <arg name="launch_driver" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
+        <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+        <arg name="container_name" value="$(var pointcloud_container_name)"/>
       </include>
     </group>
 
@@ -48,6 +52,8 @@
         <!-- <arg name="sensor_timestamp" value="false" /> -->
         <arg name="launch_driver" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
+        <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+        <arg name="container_name" value="$(var pointcloud_container_name)"/>
       </include>
     </group>
 
@@ -62,6 +68,8 @@
         <!-- <arg name="sensor_timestamp" value="false" /> -->
         <arg name="launch_driver" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
+        <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+        <arg name="container_name" value="$(var pointcloud_container_name)"/>
       </include>
     </group>
 


### PR DESCRIPTION
Signed-off-by: Kaan Colak <kcolak@leodrive.ai>

## Description

<!-- Write a brief description of this PR. -->

 Working with an individual container for each lidar increases network traffic and CPU utilization. Make it possible to pass `pointcloud_container` to Velodyne nodes.

 When working with logging_simulator.launch.xml, it decreased network utilization around ~30-40 MB/s . 

 When setting `launch_driver:=true` on `logging_simulator.launch.xml` or `autoware.launch.xml` it looks working without problem, but needs to test with real device. I will test it to make sure multiple velodyne drivers working in the same container with different namespaces without any problems.

Relevant issues and PR :
[https://github.com/autowarefoundation/autoware.universe/issues/1228](https://github.com/autowarefoundation/autoware.universe/issues/1228 )
[https://github.com/autowarefoundation/autoware.universe/pull/2114](https://github.com/autowarefoundation/autoware.universe/pull/2114)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
