### PR TITLE
fix: suppress xacro warning

### DIFF
--- a/sample_sensor_kit_description/urdf/sensor_kit.xacro
+++ b/sample_sensor_kit_description/urdf/sensor_kit.xacro
@@ -21,7 +21,7 @@
     </link>
 
     <!-- sensor -->
-    <xacro:property name="calibration" value="${load_yaml('$(arg config_dir)/sensor_kit_calibration.yaml')}"/>
+    <xacro:property name="calibration" value="${xacro.load_yaml('$(arg config_dir)/sensor_kit_calibration.yaml')}"/>
 
     <!-- lidar -->
     <xacro:VLS-128 parent="sensor_kit_base_link" name="velodyne_top" topic="/points_raw" hz="10" samples="220" gpu="$(arg gpu)">

--- a/sample_sensor_kit_description/urdf/sensors.xacro
+++ b/sample_sensor_kit_description/urdf/sensors.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot name="vehicle" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:arg name="config_dir" default="$(find sample_sensor_kit_description)/config"/>
-  <xacro:property name="calibration" value="${load_yaml('$(arg config_dir)/sensors_calibration.yaml')}"/>
+  <xacro:property name="calibration" value="${xacro.load_yaml('$(arg config_dir)/sensors_calibration.yaml')}"/>
 
   <!-- sensor kit -->
   <xacro:include filename="sensor_kit.xacro"/>


### PR DESCRIPTION
Signed-off-by: Daisuke Nishimatsu <border_goldenmarket@yahoo.co.jp>

## Description

suppress xacro warnings below.
```
warning: Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.
warning: Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.
warning: Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
