### PR TITLE
feat: rename velodyne_driver and velodyne_pointcloud package name in launch

### DIFF
--- a/common_sensor_launch/launch/velodyne_VLP16.launch.xml
+++ b/common_sensor_launch/launch/velodyne_VLP16.launch.xml
@@ -3,7 +3,7 @@
   <arg name="launch_driver" default="true"/>
 
   <arg name="model" default="VLP16"/>
-  <arg name="calibration" default="$(find-pkg-share velodyne_pointcloud)/params/VLP16db.yaml"/>
+  <arg name="calibration" default="$(find-pkg-share awf_velodyne_pointcloud)/params/VLP16db.yaml"/>
   <arg name="max_range" default="130.0"/>
   <arg name="min_range" default="0.4"/>
   <arg name="invalid_intensity" default="[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"/>

--- a/common_sensor_launch/launch/velodyne_VLS128.launch.xml
+++ b/common_sensor_launch/launch/velodyne_VLS128.launch.xml
@@ -3,7 +3,7 @@
   <arg name="launch_driver" default="true"/>
 
   <arg name="model" default="VLS128"/>
-  <arg name="calibration" default="$(find-pkg-share velodyne_pointcloud)/params/VLS-128_FS1.yaml"/>
+  <arg name="calibration" default="$(find-pkg-share awf_velodyne_pointcloud)/params/VLS-128_FS1.yaml"/>
   <arg name="max_range" default="250.0"/>
   <arg name="min_range" default="0.5"/>
   <arg

--- a/common_sensor_launch/launch/velodyne_node_container.launch.py
+++ b/common_sensor_launch/launch/velodyne_node_container.launch.py
@@ -63,7 +63,7 @@ def launch_setup(context, *args, **kwargs):
     # https://github.com/ros-drivers/velodyne/blob/ros2/velodyne_pointcloud/launch/velodyne_convert_node-VLP16-composed-launch.py
     nodes.append(
         ComposableNode(
-            package="velodyne_pointcloud",
+            package="awf_velodyne_pointcloud",
             plugin="velodyne_pointcloud::Convert",
             name="velodyne_convert_node",
             parameters=[
@@ -181,7 +181,7 @@ def launch_setup(context, *args, **kwargs):
     )
 
     driver_component = ComposableNode(
-        package="velodyne_driver",
+        package="awf_velodyne_driver",
         plugin="velodyne_driver::VelodyneDriver",
         # node is created in a global context, need to avoid name clash
         name="velodyne_driver",

--- a/common_sensor_launch/package.xml
+++ b/common_sensor_launch/package.xml
@@ -12,8 +12,8 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <exec_depend>awf_velodyne_driver</exec_depend>
-  <exec_depend>velodyne_monitor</exec_depend>
   <exec_depend>awf_velodyne_pointcloud</exec_depend>
+  <exec_depend>velodyne_monitor</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/common_sensor_launch/package.xml
+++ b/common_sensor_launch/package.xml
@@ -11,9 +11,9 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <exec_depend>velodyne_driver</exec_depend>
+  <exec_depend>awf_velodyne_driver</exec_depend>
   <exec_depend>velodyne_monitor</exec_depend>
-  <exec_depend>velodyne_pointcloud</exec_depend>
+  <exec_depend>awf_velodyne_pointcloud</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>


### PR DESCRIPTION
## Description
In order to create debian package, we are renaming velodyne driver packages by adding prefix `awf_` so that we can avoid conflict with the upstream packages.

This PR will point to the branch with renamed packages.

Related Issue:
https://github.com/autowarefoundation/autoware/issues/3222#issuecomment-1475656867
<!-- Write a brief description of this PR. -->

## Notes to reviewers
This should be merged with other PRs:
- autoware.repos https://github.com/autowarefoundation/autoware/pull/3492
- awsim_sensor_kit_launch: https://github.com/RobotecAI/awsim_sensor_kit_launch/pull/7

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
