### PR TITLE
refactor(sample_sensor_kit_launch): remove unnecessary gnss_poser arguments

### DIFF
--- a/sample_sensor_kit_launch/launch/gnss.launch.xml
+++ b/sample_sensor_kit_launch/launch/gnss.launch.xml
@@ -1,7 +1,6 @@
 <launch>
   <arg name="launch_driver" default="true"/>
   <arg name="gnss_receiver" default="ublox" description="ublox(default) or septentrio"/>
-  <arg name="coordinate_system" default="1" description="0:UTM, 1:MGRS, 2:PLANE"/>
 
   <group>
     <push-ros-namespace namespace="gnss"/>
@@ -25,18 +24,6 @@
     </group>
 
     <!-- NavSatFix to MGRS Pose -->
-    <include file="$(find-pkg-share gnss_poser)/launch/gnss_poser.launch.xml">
-      <arg name="input_topic_fix" value="$(var navsatfix_topic_name)"/>
-      <arg name="input_topic_orientation" value="$(var orientation_topic_name)"/>
-
-      <arg name="output_topic_gnss_pose" value="pose"/>
-      <arg name="output_topic_gnss_pose_cov" value="pose_with_covariance"/>
-      <arg name="output_topic_gnss_fixed" value="fixed"/>
-
-      <arg name="coordinate_system" value="$(var coordinate_system)"/>
-      <arg name="use_gnss_ins_orientation" value="true"/>
-
-      <arg name="gnss_frame" value="gnss_link"/>
-    </include>
+    <include file="$(find-pkg-share gnss_poser)/launch/gnss_poser.launch.xml"/>
   </group>
 </launch>


### PR DESCRIPTION
## Description

This PR removes unnecessary arguments from launch file.
Releated autoware.universe PR: https://github.com/autowarefoundation/autoware.universe/pull/4277

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
