### PR TITLE
refactor(nebula launch): consistent naming for sensor_ip parameter

### DIFF
--- a/common_sensor_launch/launch/velodyne_VLP16.launch.xml
+++ b/common_sensor_launch/launch/velodyne_VLP16.launch.xml
@@ -6,7 +6,7 @@
   <arg name="min_range" default="0.4"/>
   <arg name="sensor_frame" default="velodyne"/>
   <arg name="return_mode" default="SingleStrongest"/>
-  <arg name="device_ip" default="192.168.1.201"/>
+  <arg name="sensor_ip" default="192.168.1.201"/>
   <arg name="host_ip" default="255.255.255.255"/>
   <arg name="data_port" default="2368"/>
   <arg name="scan_phase" default="0.0"/>
@@ -23,7 +23,7 @@
     <arg name="max_range" value="$(var max_range)"/>
     <arg name="min_range" value="$(var min_range)"/>
     <arg name="frame_id" value="$(var sensor_frame)"/>
-    <arg name="sensor_ip" value="$(var device_ip)"/>
+    <arg name="sensor_ip" value="$(var sensor_ip)"/>
     <arg name="host_ip" value="$(var host_ip)"/>
     <arg name="data_port" value="$(var data_port)"/>
     <arg name="scan_phase" value="$(var scan_phase)"/>
@@ -38,6 +38,6 @@
 
   <!-- Velodyne Monitor -->
   <include file="$(find-pkg-share velodyne_monitor)/launch/velodyne_monitor.launch.xml" if="$(var launch_driver)">
-    <arg name="ip_address" value="$(var device_ip)"/>
+    <arg name="ip_address" value="$(var sensor_ip)"/>
   </include>
 </launch>

--- a/common_sensor_launch/launch/velodyne_VLS128.launch.xml
+++ b/common_sensor_launch/launch/velodyne_VLS128.launch.xml
@@ -6,7 +6,7 @@
   <arg name="min_range" default="0.5"/>
   <arg name="sensor_frame" default="velodyne"/>
   <arg name="return_mode" default="SingleStrongest"/>
-  <arg name="device_ip" default="192.168.1.201"/>
+  <arg name="sensor_ip" default="192.168.1.201"/>
   <arg name="host_ip" default="255.255.255.255"/>
   <arg name="data_port" default="2368"/>
   <arg name="scan_phase" default="0.0"/>
@@ -23,7 +23,7 @@
     <arg name="max_range" value="$(var max_range)"/>
     <arg name="min_range" value="$(var min_range)"/>
     <arg name="frame_id" value="$(var sensor_frame)"/>
-    <arg name="sensor_ip" value="$(var device_ip)"/>
+    <arg name="sensor_ip" value="$(var sensor_ip)"/>
     <arg name="host_ip" value="$(var host_ip)"/>
     <arg name="data_port" value="$(var data_port)"/>
     <arg name="scan_phase" value="$(var scan_phase)"/>
@@ -38,6 +38,6 @@
 
   <!-- Velodyne Monitor -->
   <include file="$(find-pkg-share velodyne_monitor)/launch/velodyne_monitor.launch.xml" if="$(var launch_driver)">
-    <arg name="ip_address" value="$(var device_ip)"/>
+    <arg name="ip_address" value="$(var sensor_ip)"/>
   </include>
 </launch>

--- a/sample_sensor_kit_launch/launch/lidar.launch.xml
+++ b/sample_sensor_kit_launch/launch/lidar.launch.xml
@@ -15,7 +15,7 @@
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLS128.launch.xml">
         <arg name="max_range" value="250.0"/>
         <arg name="sensor_frame" value="velodyne_top"/>
-        <arg name="device_ip" value="192.168.1.201"/>
+        <arg name="sensor_ip" value="192.168.1.201"/>
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2368"/>
         <arg name="scan_phase" value="300.0"/>
@@ -31,7 +31,7 @@
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLP16.launch.xml">
         <arg name="max_range" value="5.0"/>
         <arg name="sensor_frame" value="velodyne_left"/>
-        <arg name="device_ip" value="192.168.1.202"/>
+        <arg name="sensor_ip" value="192.168.1.202"/>
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2369"/>
         <arg name="scan_phase" value="180.0"/>
@@ -49,7 +49,7 @@
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLP16.launch.xml">
         <arg name="max_range" value="5.0"/>
         <arg name="sensor_frame" value="velodyne_right"/>
-        <arg name="device_ip" value="192.168.1.203"/>
+        <arg name="sensor_ip" value="192.168.1.203"/>
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2370"/>
         <arg name="scan_phase" value="180.0"/>
@@ -67,7 +67,7 @@
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLP16.launch.xml">
         <arg name="max_range" value="1.5"/>
         <arg name="sensor_frame" value="velodyne_rear"/>
-        <arg name="device_ip" value="192.168.1.204"/>
+        <arg name="sensor_ip" value="192.168.1.204"/>
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2371"/>
         <arg name="scan_phase" value="180.0"/>


### PR DESCRIPTION
## Description

This PR renames all instances of the `device_ip` parameter to `sensor_ip` to avoid confusion in the LiDAR launchfiles.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
