### PR TITLE
refactor: rename lidar topic

### DIFF
--- a/common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/common_sensor_launch/launch/nebula_node_container.launch.py
@@ -187,7 +187,7 @@ def launch_setup(context, *args, **kwargs):
             name="ring_outlier_filter",
             remappings=[
                 ("input", "rectified/pointcloud_ex"),
-                ("output", "outlier_filtered/pointcloud"),
+                ("output", "pointcloud"),
             ],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         )

--- a/sample_sensor_kit_launch/launch/pointcloud_preprocessor.launch.py
+++ b/sample_sensor_kit_launch/launch/pointcloud_preprocessor.launch.py
@@ -38,9 +38,9 @@ def launch_setup(context, *args, **kwargs):
         parameters=[
             {
                 "input_topics": [
-                    "/sensing/lidar/top/outlier_filtered/pointcloud",
-                    "/sensing/lidar/left/outlier_filtered/pointcloud",
-                    "/sensing/lidar/right/outlier_filtered/pointcloud",
+                    "/sensing/lidar/top/pointcloud",
+                    "/sensing/lidar/left/pointcloud",
+                    "/sensing/lidar/right/pointcloud",
                 ],
                 "output_frame": LaunchConfiguration("base_frame"),
                 "input_twist_topic_type": "twist",


### PR DESCRIPTION
## Description

rename output lidar topic.
`/sensing/lidar/<lidar name>/outlier_filtered/pointcloud` --> `/sensing/lidar/<lidar name>/pointcloud`

## Related PRs

**Merge all Related PRs at the same time.**

https://github.com/autowarefoundation/autoware-documentation/pull/491
https://github.com/autowarefoundation/autoware.universe/pull/5781
https://github.com/autowarefoundation/sample_sensor_kit_launch/pull/82
https://github.com/autowarefoundation/autoware_launch/pull/722
https://github.com/RobotecAI/awsim_sensor_kit_launch/pull/12
https://github.com/autowarefoundation/awf_reference_sensor_kit_launch/pull/7

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
