### PR TITLE
feat(pointcloud_preprocessing): enable to publish synchronized pointclouds

### DIFF
--- a/sample_sensor_kit_launch/launch/pointcloud_preprocessor.launch.py
+++ b/sample_sensor_kit_launch/launch/pointcloud_preprocessor.launch.py
@@ -44,7 +44,9 @@ def launch_setup(context, *args, **kwargs):
                 ],
                 "output_frame": LaunchConfiguration("base_frame"),
                 "input_twist_topic_type": "twist",
-                "publish_synchronized_pointcloud": LaunchConfiguration("publish_synchronized_pointcloud"),
+                "publish_synchronized_pointcloud": LaunchConfiguration(
+                    "concatenate_node__publish_synchronized_pointcloud"
+                ),
             }
         ],
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
@@ -88,7 +90,7 @@ def generate_launch_description():
     add_launch_arg("use_intra_process", "False")
     add_launch_arg("use_pointcloud_container", "False")
     add_launch_arg("container_name", "pointcloud_preprocessor_container")
-    add_launch_arg("publish_synchronized_pointcloud", "False")
+    add_launch_arg("concatenate_node__publish_synchronized_pointcloud", "False")
 
     set_container_executable = SetLaunchConfiguration(
         "container_executable",

--- a/sample_sensor_kit_launch/launch/pointcloud_preprocessor.launch.py
+++ b/sample_sensor_kit_launch/launch/pointcloud_preprocessor.launch.py
@@ -44,6 +44,7 @@ def launch_setup(context, *args, **kwargs):
                 ],
                 "output_frame": LaunchConfiguration("base_frame"),
                 "input_twist_topic_type": "twist",
+                "publish_synchronized_pointcloud": LaunchConfiguration("publish_synchronized_pointcloud"),
             }
         ],
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
@@ -87,6 +88,7 @@ def generate_launch_description():
     add_launch_arg("use_intra_process", "False")
     add_launch_arg("use_pointcloud_container", "False")
     add_launch_arg("container_name", "pointcloud_preprocessor_container")
+    add_launch_arg("publish_synchronized_pointcloud", "False")
 
     set_container_executable = SetLaunchConfiguration(
         "container_executable",


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

This PR is part of the multi-lidar occupancy grid map generation.
It enables to pointcloud concatenate node to publish synchronized pointclouds in each sensors.

![image](https://github.com/autowarefoundation/sample_sensor_kit_launch/assets/20086766/ab632eed-5a08-4a5f-b171-40e0f7875435)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
