### PR TITLE
fix(nebula node container): fix if condition for ring outlier filter

### DIFF
--- a/common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/common_sensor_launch/launch/nebula_node_container.launch.py
@@ -189,7 +189,7 @@ def launch_setup(context, *args, **kwargs):
     )
 
     # Ring Outlier Filter is the last component in the pipeline, so control the output frame here
-    if LaunchConfiguration("output_as_sensor_frame").perform(context):
+    if LaunchConfiguration("output_as_sensor_frame").perform(context).lower() == "true":
         ring_outlier_filter_parameters = {"output_frame": LaunchConfiguration("frame_id")}
     else:
         ring_outlier_filter_parameters = {


### PR DESCRIPTION
## Description
The previous parameter `output_frame` in ring outlier filter will always change from `base_link` back to `sensor_frame` because the `if LaunchConfiguration("output_as_sensor_frame").perform(context)` is always [true](url). 

That is because ` LaunchConfiguration("output_as_sensor_frame").perform(context)` is a string.


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
