### PR TITLE
refactor(nebula_node_container): support Nebula single-node architecture

### DIFF
--- a/common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/common_sensor_launch/launch/nebula_node_container.launch.py
@@ -94,9 +94,7 @@ def launch_setup(context, *args, **kwargs):
 
     # Pointcloud preprocessor parameters
     distortion_corrector_node_param = ParameterFile(
-        param_file=LaunchConfiguration("distortion_correction_node_param_path").perform(
-            context
-        ),
+        param_file=LaunchConfiguration("distortion_correction_node_param_path").perform(context),
         allow_substs=True,
     )
 


### PR DESCRIPTION
## Description

This PR makes the changes necessary to support the new Nebula single-node architecture.
These changes can be summarized as:

- merge the separate Nebula nodes into one in the launch file
- find and read default sensor config file in case none is specified. Parameters specified as arguments will override the values in the file

:warning: This PR has to be merged in a coordinated manner with the corresponding PRs listed below. The timeline is currently being discussed.

## Related links

**Internal Tickets:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT1-7076) -- parent issue
- [TIER IV internal link](https://tier4.atlassian.net/browse/RT1-7078) -- this issue

**Depends on:**

- autowarefoundation/autoware#5008
- tier4/nebula#176

## How was this PR tested?

- TBA

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

Nebula should experience less packet loss & other issues. The hardware monitor is now launched when `launch_driver` is true (was not launched at all before). No other behavioral changes expected.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
