### PR TITLE
feat(common_sensor_launch): filter load param from file

### DIFF
--- a/common_sensor_launch/config/filter.param.yaml
+++ b/common_sensor_launch/config/filter.param.yaml
@@ -1,0 +1,8 @@
+/**:
+  ros__parameters:
+    input_frame: ""
+    output_frame: ""
+    max_queue_size: 5
+    use_indices: false
+    latched_indices: false
+    approximate_sync: false

--- a/common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/common_sensor_launch/launch/nebula_node_container.launch.py
@@ -180,7 +180,7 @@ def launch_setup(context, *args, **kwargs):
                 ("input", "self_cropped/pointcloud_ex"),
                 ("output", "mirror_cropped/pointcloud_ex"),
             ],
-            parameters=[cropbox_parameters],
+            parameters=[filter_param, cropbox_parameters],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         )
     )

--- a/common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/common_sensor_launch/launch/nebula_node_container.launch.py
@@ -86,6 +86,10 @@ def launch_setup(context, *args, **kwargs):
     ), "Sensor calib file under calibration/ was not found: {}".format(sensor_calib_fp)
 
     # Pointcloud preprocessor parameters
+    filter_param = ParameterFile(
+        param_file=LaunchConfiguration("filter_param_path").perform(context),
+        allow_substs=True,
+    )
     distortion_corrector_node_param = ParameterFile(
         param_file=LaunchConfiguration("distortion_correction_node_param_path").perform(context),
         allow_substs=True,
@@ -154,7 +158,7 @@ def launch_setup(context, *args, **kwargs):
                 ("input", "pointcloud_raw_ex"),
                 ("output", "self_cropped/pointcloud_ex"),
             ],
-            parameters=[cropbox_parameters],
+            parameters=[filter_param, cropbox_parameters],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         )
     )
@@ -213,7 +217,7 @@ def launch_setup(context, *args, **kwargs):
                 ("input", "rectified/pointcloud_ex"),
                 ("output", "pointcloud_before_sync"),
             ],
-            parameters=[ring_outlier_filter_parameters],
+            parameters=[filter_param, ring_outlier_filter_parameters],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         )
     )
@@ -302,6 +306,16 @@ def generate_launch_description():
     add_launch_arg("output_as_sensor_frame", "True", "output final pointcloud in sensor frame")
     add_launch_arg(
         "vehicle_mirror_param_file", description="path to the file of vehicle mirror position yaml"
+    )
+
+    add_launch_arg(
+        "filter_param_path",
+        os.path.join(
+            common_sensor_share_dir,
+            "config",
+            "filter.param.yaml",
+        ),
+        description="path to parameter file of filter",
     )
     add_launch_arg(
         "distortion_correction_node_param_path",


### PR DESCRIPTION
## Description

- https://github.com/autowarefoundation/autoware.universe/pull/8469
removes the default parameters for filter.cpp.
Thus, nebula_node_container.launch.py need to load filter parameter from parameter file

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
- https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch/pull/8

## Tests performed
`ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-rosbag vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit`
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
