### PR TITLE
feat: acceleration and transport layer

### DIFF
--- a/common_sensor_launch/launch/robosense_Bpearl.launch.xml
+++ b/common_sensor_launch/launch/robosense_Bpearl.launch.xml
@@ -15,6 +15,9 @@
   <arg name="cloud_max_angle" default="360"/>
   <arg name="vehicle_mirror_param_file"/>
   <arg name="container_name" default="robosense_node_container"/>
+  <arg name="pointcloud_container_name" default="pointcloud_container"/>
+  <arg name="use_pointcloud_container" default="false"/>
+  <arg name="use_cuda_preprocessor" default="false"/>
 
   <include file="$(find-pkg-share common_sensor_launch)/launch/nebula_node_container.launch.py">
     <arg name="launch_driver" value="$(var launch_driver)"/>
@@ -33,5 +36,8 @@
     <arg name="use_intra_process" value="true"/>
     <arg name="use_multithread" value="false"/>
     <arg name="container_name" value="$(var container_name)"/>
+    <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
+    <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+    <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
   </include>
 </launch>

--- a/common_sensor_launch/launch/robosense_Helios.launch.xml
+++ b/common_sensor_launch/launch/robosense_Helios.launch.xml
@@ -15,6 +15,9 @@
   <arg name="cloud_max_angle" default="360"/>
   <arg name="vehicle_mirror_param_file"/>
   <arg name="container_name" default="robosense_node_container"/>
+  <arg name="pointcloud_container_name" default="pointcloud_container"/>
+  <arg name="use_pointcloud_container" default="false"/>
+  <arg name="use_cuda_preprocessor" default="false"/>
 
   <include file="$(find-pkg-share common_sensor_launch)/launch/nebula_node_container.launch.py">
     <arg name="launch_driver" value="$(var launch_driver)"/>
@@ -33,5 +36,8 @@
     <arg name="use_intra_process" value="true"/>
     <arg name="use_multithread" value="false"/>
     <arg name="container_name" value="$(var container_name)"/>
+    <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
+    <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+    <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
   </include>
 </launch>

--- a/common_sensor_launch/launch/velodyne_VLP16.launch.xml
+++ b/common_sensor_launch/launch/velodyne_VLP16.launch.xml
@@ -14,6 +14,9 @@
   <arg name="cloud_max_angle" default="360"/>
   <arg name="vehicle_mirror_param_file"/>
   <arg name="container_name" default="velodyne_node_container"/>
+  <arg name="pointcloud_container_name" default="pointcloud_container"/>
+  <arg name="use_pointcloud_container" default="false"/>
+  <arg name="use_cuda_preprocessor" default="false"/>
 
   <include file="$(find-pkg-share common_sensor_launch)/launch/nebula_node_container.launch.py">
     <arg name="launch_driver" value="$(var launch_driver)"/>
@@ -32,6 +35,9 @@
     <arg name="use_intra_process" value="true"/>
     <arg name="use_multithread" value="false"/>
     <arg name="container_name" value="$(var container_name)"/>
+    <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
+    <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+    <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
   </include>
 
   <!-- Velodyne Monitor -->

--- a/common_sensor_launch/launch/velodyne_VLS128.launch.xml
+++ b/common_sensor_launch/launch/velodyne_VLS128.launch.xml
@@ -14,6 +14,9 @@
   <arg name="cloud_max_angle" default="360"/>
   <arg name="vehicle_mirror_param_file"/>
   <arg name="container_name" default="velodyne_node_container"/>
+  <arg name="pointcloud_container_name" default="pointcloud_container"/>
+  <arg name="use_pointcloud_container" default="false"/>
+  <arg name="use_cuda_preprocessor" default="false"/>
 
   <include file="$(find-pkg-share common_sensor_launch)/launch/nebula_node_container.launch.py">
     <arg name="launch_driver" value="$(var launch_driver)"/>
@@ -32,6 +35,9 @@
     <arg name="use_intra_process" value="true"/>
     <arg name="use_multithread" value="true"/>
     <arg name="container_name" value="$(var container_name)"/>
+    <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
+    <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+    <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
   </include>
 
   <!-- Velodyne Monitor -->

--- a/sample_sensor_kit_launch/config/concatenate_and_time_sync_node.param.yaml
+++ b/sample_sensor_kit_launch/config/concatenate_and_time_sync_node.param.yaml
@@ -1,0 +1,22 @@
+/**:
+  ros__parameters:
+    debug_mode: false
+    has_static_tf_only: false
+    rosbag_replay: false
+    rosbag_length: 20.0
+    maximum_queue_size: 5
+    timeout_sec: 0.2
+    is_motion_compensated: true
+    publish_synchronized_pointcloud: true
+    keep_input_frame_in_synchronized_pointcloud: true
+    publish_previous_but_late_pointcloud: false
+    synchronized_pointcloud_postfix: pointcloud
+    input_twist_topic_type: twist
+    input_topics: [
+                    "/sensing/lidar/right/pointcloud_before_sync",
+                    "/sensing/lidar/top/pointcloud_before_sync",
+                    "/sensing/lidar/left/pointcloud_before_sync",
+                ]
+    output_frame: base_link
+    lidar_timestamp_offsets: [0.0, 0.015, 0.016]
+    lidar_timestamp_noise_window: [0.01, 0.01, 0.01]

--- a/sample_sensor_kit_launch/config/concatenate_and_time_sync_node.param.yaml
+++ b/sample_sensor_kit_launch/config/concatenate_and_time_sync_node.param.yaml
@@ -1,5 +1,6 @@
 /**:
   ros__parameters:
+    use_cuda: true
     debug_mode: false
     has_static_tf_only: false
     rosbag_replay: false

--- a/sample_sensor_kit_launch/launch/lidar.launch.xml
+++ b/sample_sensor_kit_launch/launch/lidar.launch.xml
@@ -5,6 +5,8 @@
   <arg name="vehicle_id" default="$(env VEHICLE_ID default)"/>
   <arg name="vehicle_mirror_param_file"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
+  <arg name="use_pointcloud_container" default="true"/>
+  <arg name="use_cuda_preprocessor" default="true"/>
 
   <group>
     <push-ros-namespace namespace="lidar"/>
@@ -21,6 +23,9 @@
         <arg name="launch_driver" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
         <arg name="container_name" value="pointcloud_container"/>
+        <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
+        <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+        <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
       </include>
     </group>
 
@@ -38,6 +43,9 @@
         <arg name="launch_driver" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
         <arg name="container_name" value="pointcloud_container"/>
+        <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
+        <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+        <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
       </include>
     </group>
 
@@ -55,6 +63,9 @@
         <arg name="launch_driver" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
         <arg name="container_name" value="pointcloud_container"/>
+        <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
+        <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+        <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
       </include>
     </group>
 
@@ -72,6 +83,9 @@
         <arg name="launch_driver" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
         <arg name="container_name" value="pointcloud_container"/>
+        <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
+        <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+        <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
       </include>
     </group>
 

--- a/sample_sensor_kit_launch/launch/pointcloud_preprocessor.launch.py
+++ b/sample_sensor_kit_launch/launch/pointcloud_preprocessor.launch.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 
+from ament_index_python.packages import get_package_share_directory
 import launch
 from launch.actions import DeclareLaunchArgument
 from launch.actions import OpaqueFunction
@@ -22,9 +24,18 @@ from launch.conditions import UnlessCondition
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
+from launch_ros.parameter_descriptions import ParameterFile
 
 
 def launch_setup(context, *args, **kwargs):
+    # concatenate node parameters
+    concatenate_and_time_sync_node_param = ParameterFile(
+        param_file=LaunchConfiguration("concatenate_and_time_sync_node_param_path").perform(
+            context
+        ),
+        allow_substs=True,
+    )
+
     # set concat filter as a component
     concat_component = ComposableNode(
         package="autoware_pointcloud_preprocessor",
@@ -34,18 +45,7 @@ def launch_setup(context, *args, **kwargs):
             ("~/input/twist", "/sensing/vehicle_velocity_converter/twist_with_covariance"),
             ("output", "concatenated/pointcloud"),
         ],
-        parameters=[
-            {
-                "input_topics": [
-                    "/sensing/lidar/top/pointcloud_before_sync",
-                    "/sensing/lidar/left/pointcloud_before_sync",
-                    "/sensing/lidar/right/pointcloud_before_sync",
-                ],
-                "output_frame": LaunchConfiguration("base_frame"),
-                "input_twist_topic_type": "twist",
-                "publish_synchronized_pointcloud": True,
-            }
-        ],
+        parameters=[concatenate_and_time_sync_node_param],
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
     )
 
@@ -65,10 +65,20 @@ def generate_launch_description():
     def add_launch_arg(name: str, default_value=None):
         launch_arguments.append(DeclareLaunchArgument(name, default_value=default_value))
 
+    sample_sensor_kit_launch_share_dir = get_package_share_directory("sample_sensor_kit_launch")
+
     add_launch_arg("base_frame", "base_link")
     add_launch_arg("use_multithread", "False")
     add_launch_arg("use_intra_process", "False")
     add_launch_arg("pointcloud_container_name", "pointcloud_container")
+    add_launch_arg(
+        "concatenate_and_time_sync_node_param_path",
+        os.path.join(
+            sample_sensor_kit_launch_share_dir,
+            "config",
+            "concatenate_and_time_sync_node.param.yaml",
+        ),
+    )
 
     set_container_executable = SetLaunchConfiguration(
         "container_executable",

--- a/sample_sensor_kit_launch/launch/pointcloud_preprocessor.launch.py
+++ b/sample_sensor_kit_launch/launch/pointcloud_preprocessor.launch.py
@@ -46,7 +46,8 @@ def launch_setup(context, *args, **kwargs):
             ("output", "concatenated/pointcloud"),
         ],
         parameters=[concatenate_and_time_sync_node_param],
-        extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
+        # The whole node can not set use_intra_process due to type negotiation internal topics
+        # extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
     )
 
     # load concat or passthrough filter


### PR DESCRIPTION
## Description
This PR is part of a series of PRs that aim to accelerate the Sensing/Perception pipeline through an appropriate use of CUDA.

List of PRs:
 - https://github.com/autowarefoundation/autoware.universe/pull/9454 (pointcloud preprocessing)
 - https://github.com/autowarefoundation/autoware.universe/pull/9455 (concatenation)
 - https://github.com/autowarefoundation/autoware.universe/pull/9453 (centerpoint)
 - transfusion (TODO)
 - OGM (TODO)
 - https://github.com/tier4/aip_launcher/pull/348 (aip_launcher)
 - https://github.com/autowarefoundation/sample_sensor_kit_launch/pull/111 (sample_sensor_kit_launch)

To use these branches, the following additions to the `autoware.repos` are necessary:

```text
  vendor/cuda_blackboard:
    type: git
    url: git@github.com:knzo25/cuda_blackboard.git
    version: main
  vendor/negotiated:
    type: git
    url: https://github.com/osrf/negotiated.git
    version: master
```

Depending on your machine and how many nodes are in a container, the following branch may also be required:
https://github.com/knzo25/launch_ros/tree/fix/load_composable_node
There seems to be a but in ROS where if you send too many services at once some will be lost and `ros_launch` can not handle that.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
The sensing/perception pipeline was tested until centerpoint for TIER IV's taxi using the logging simulator.

## Notes for reviewers
The main branch that I used for development is [`feat/cuda_acceleration_and_transport_layer`](https://github.com/knzo25/autoware.universe/tree/feat/cuda_acceleration_and_transport_layer).
However, the changes were too big so I split the PRs. That being said, development, if any will still be on that branch (and then cherrypicked to the respective PRs), and the review changes will be cherrypicked into the development branch.

## Interface changes

An additional topic is added to perform type negotiation:
Example: `input/pointcloud` -> `input/pointcloud` and `input/pointcloud/cuda`

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

Enabling this preprocessing in the launchers should provide a much reduced latency and cpu usage (at the cost of a higher GPU usage)
