### PR TITLE
refactor(sample_sensor_kit_launch): remove reference to tamagawa_imu_driver

### DIFF
--- a/sample_sensor_kit_launch/launch/imu.launch.xml
+++ b/sample_sensor_kit_launch/launch/imu.launch.xml
@@ -4,14 +4,14 @@
   <group>
     <push-ros-namespace namespace="imu"/>
 
-    <group>
+    <!-- <group>
       <push-ros-namespace namespace="tamagawa"/>
       <node pkg="tamagawa_imu_driver" name="tag_serial_driver" exec="tag_serial_driver" if="$(var launch_driver)">
         <remap from="imu/data_raw" to="imu_raw"/>
         <param name="port" value="/dev/imu"/>
         <param name="imu_frame_id" value="tamagawa/imu_link"/>
       </node>
-    </group>
+    </group> -->
 
     <arg name="imu_raw_name" default="tamagawa/imu_raw"/>
     <arg name="imu_corrector_param_file" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)/sample_sensor_kit/imu_corrector.param.yaml"/>

--- a/sample_sensor_kit_launch/package.xml
+++ b/sample_sensor_kit_launch/package.xml
@@ -14,7 +14,6 @@
   <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
   <exec_depend>autoware_vehicle_velocity_converter</exec_depend>
   <exec_depend>common_sensor_launch</exec_depend>
-  <exec_depend>tamagawa_imu_driver</exec_depend>
   <exec_depend>topic_tools</exec_depend>
   <exec_depend>ublox_gps</exec_depend>
   <exec_depend>usb_cam</exec_depend>


### PR DESCRIPTION
## Description

This PR removes the `tamagawa_imu_driver` package from the dependency list.

See https://github.com/autowarefoundation/autoware/issues/5804 and https://github.com/autowarefoundation/autoware/issues/3366#issuecomment-2664445289

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
